### PR TITLE
minor bugfix to add missing factor of 1/dlnf in definition of loud so…

### DIFF
--- a/holodeck/gravwaves.py
+++ b/holodeck/gravwaves.py
@@ -273,7 +273,7 @@ def _gws_harmonics_at_evo_fobs(fobs_gw, dlnf, evo, harm_range, nreals, box_vol, 
 
     if np.any(num_pois > 0):
         # Find the L loudest binaries in each realizations
-        loud = np.sort(temp[:, np.newaxis] * (num_pois > 0), axis=0)[::-1, :]
+        loud = np.sort(temp[:, np.newaxis] * (num_pois > 0) / dlnf, axis=0)[::-1, :]
         fore = loud[0, :]
         loud = loud[:loudest, :]
     else:


### PR DESCRIPTION
…urce strains in gravwaves._gws_harmonics_at_evo_fobs()

## Description
merge branch created for single commit for this bugfix

## Todos
Adds a missing factor of 1/dlnf in the definition of loud source strains in the function `_gws_harmonics_at_evo_fobs()` in `gravwaves.py`. Makes definition consistent with definition of `gwb_harms` and `both` in that function

## Questions
none

## Status
- [X] Ready to go