### PR TITLE
fix(tests): apply lowz cutoff to number density

### DIFF
--- a/.github/workflows/unit-tests-ci.yaml
+++ b/.github/workflows/unit-tests-ci.yaml
@@ -44,9 +44,12 @@ jobs:
     #   run: sudo apt-get update
     #   run: sudo apt-get install libopenmpi-dev
 
-    # - if: matrix.os == 'macOS-latest'
-    #   run: |
-    #         brew install mpich
+    - name: Set up macOS-latest conda
+      if: matrix.os == 'macOS-latest'
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-activate: false
+        activate-environment: ""
 
     - name: Install dependencies
       run: |

--- a/holodeck/sams/tests/test_sam.py
+++ b/holodeck/sams/tests/test_sam.py
@@ -237,8 +237,26 @@ def test_dbn_phenom():
     num_py = holo.sams.sam_cyutils.integrate_differential_number_3dx1d(edges_py, dnum_py)
     num_cy = holo.sams.sam_cyutils.integrate_differential_number_3dx1d(edges_cy, dnum_cy)
 
+    # Integration uses 3D trapezoid rule over (mtot, mrat, redz), so each integrated bin
+    # is computed by averaging dnum at 8 corner vertices of a cube.
+    # For integrated bin [mm, qq, zz, ff], the 8 vertices are at positions:
+    #   [mm:mm+2, qq:qq+2, zz:zz+2, ff]  (all combinations of +-1 offsets in mtot, mrat, redz)
+    #
+    # We've already decided to allow differences at low redshifts. So, the below mask
+    # excludes bins where any contributing vertex has redz_not_ignore=False.
+    num_not_ignore = (
+        redz_not_ignore[:-1, :-1, :-1, :] &  # [mtot, mrat, redz, freq]
+        redz_not_ignore[1:,  :-1, :-1, :] &  # [mtot+1, mrat, redz, freq]
+        redz_not_ignore[:-1, 1:,  :-1, :] &  # [mtot, mrat+1, redz, freq]
+        redz_not_ignore[1:,  1:,  :-1, :] &  # [mtot+1, mrat+1, redz, freq]
+        redz_not_ignore[:-1, :-1, 1:,  :] &  # [mtot, mrat, redz+1, freq]
+        redz_not_ignore[1:,  :-1, 1:,  :] &  # [mtot+1, mrat, redz+1, freq]
+        redz_not_ignore[:-1, 1:,  1:,  :] &  # [mtot, mrat+1, redz+1, freq]
+        redz_not_ignore[1:,  1:,  1:,  :]    # [mtot+1, mrat+1, redz+1, freq]
+    )
+
     # Make sure that `atol` is also set to a reasonable value
-    bads = ~np.isclose(num_py, num_cy, rtol=1e-2, atol=1.0e-1)
+    bads = ~np.isclose(num_py, num_cy, rtol=1e-2, atol=1.0e-1) & num_not_ignore
     if np.any(bads):
         print(f"{utils.frac_str(bads)=}")
         print(f"{num_py[bads][:10]=}")

--- a/notebooks/relations.ipynb
+++ b/notebooks/relations.ipynb
@@ -312,7 +312,7 @@
     "\n",
     "zz = [5.01]\n",
     "mm = [11.5]\n",
-    "hh = rooz._mhalo_from_mstar_redz(np.atleast_2d([mm, zz]).T)[0]\n",
+    "hh = rooz.halo_mass(mstar=[10**mm[0]*MSOL], redz=zz)[0]\n",
     "print(f\"hh={hh:.4e}\")\n",
     "ax.scatter(mm, zz, c=smap.to_rgba(hh), edgecolor='r', lw=2.0)\n",
     "\n",


### PR DESCRIPTION
## Description
Fixes failing tests due to a low-z cutoff that wasn't applied uniformly.

## Status
- [x] Works on my machine
- [x] Works on GitHub Actions