### PR TITLE
fix-redshift-minus-one-lib_tools-gravwaves

### DIFF
--- a/holodeck/gravwaves.py
+++ b/holodeck/gravwaves.py
@@ -273,7 +273,7 @@ def _gws_harmonics_at_evo_fobs(fobs_gw, dlnf, evo, harm_range, nreals, box_vol, 
 
     if np.any(num_pois > 0):
         # Find the L loudest binaries in each realizations
-        loud = np.sort(temp[:, np.newaxis] * (num_pois > 0), axis=0)[::-1, :]
+        loud = np.sort(temp[:, np.newaxis] * (num_pois > 0) / dlnf, axis=0)[::-1, :]
         fore = loud[0, :]
         loud = loud[:loudest, :]
     else:
@@ -719,7 +719,9 @@ def char_strain_sq_from_bin_edges_redz(edges, redz):
 
     # convert from observer-frame to rest-frame; still using frequency-bin centers
     fr = utils.frst_from_fobs(fc[np.newaxis, np.newaxis, np.newaxis, :], redz)
-
+    # redz is set to -np.inf instead of -1, which makes fr negative and creates a nan error in hs calculation
+    # so, to avoid nan, setting those fr to zero
+    fr[fr<0] = 0.0
     hs = utils.gw_strain_source(mc, dc, fr)
     hc2 = (hs ** 2) * (fc / df)
     return hc2

--- a/holodeck/librarian/lib_tools.py
+++ b/holodeck/librarian/lib_tools.py
@@ -836,6 +836,8 @@ def run_model(
             data['hc_bg'] = hc_bg
 
     if gwb_flag:
+        negative_mask = use_redz < 0.0 # galaxy mergers that stall
+        use_redz[negative_mask] = -np.inf # set to -inf so they can't contribute to GWB
         gwb = holo.gravwaves._gws_from_number_grid_integrated_redz(edges, use_redz, number, nreals)
         data['gwb'] = gwb
 


### PR DESCRIPTION
## Description

Setting redz=-1.0 for the binaries not merging within the age of the universe causes problems. -1 is used as a flag to identify such binaries, but that redshift value is used in averaging, which can cause troubles.

While converting the redz_final from (91, 81, 101, 5) to (90, 80, 100, 5), i.e. going from bin edges to bin midpoints, the average is taken of the 8 vertex redshift values to obtain an average bin mid-point value. That -1 was creating problem by occasionally causing very small positive midpoint redshift values.

My fix changes the flag value from -1 to -np.inf in **librarian/lib_tools.py**. So that in averaging, the result can't become accidentally positive.

This, however, creates nan values for those bins in **gravwaves.py** _hs_ calculation in the function _char_strain_sq_from_bin_edges_redz_. I fix that by simply applying a filter there.