### PR TITLE
Fix nbstripout config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ipynb filter=nbstripout
+*.ipynb diff=ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,6 @@ run_gen_lib_sams__*
 *.ini
 *.c
 *.html
-.gitattributes
 *.slurm
 
 # Mac Desktop Services

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ A single [environment.yml](environment.yml) creates an env named `holopy` with a
 ```
 mamba env create -f environment.yml       # fast; use `conda` if you prefer
 mamba activate holopy
+nbstripout --install
+git config filter.nbstripout.extrakeys 'metadata.kernelspec metadata.language_info.version'
 ```
 
 If needed, the installation can also be performed with `conda`, however it is much slower 


### PR DESCRIPTION
## Description
moved `.gitattributes` out of `.gitignore` for standardized development filters. Added instructions to `README.md` to get nbstripout working correctly.
## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Standardized development environment.

## Status
- [x] Ready to go


Request review from @mssiwek 