### PR TITLE
Made core library LaTeX strings raw strings to prevent bad escape warnings

### DIFF
--- a/holodeck/accretion.py
+++ b/holodeck/accretion.py
@@ -89,7 +89,7 @@ class Accretion:
             self.swk_acc = lambda_qe_interp_2d()
 
     def mdot_eddington(self, mass, eps=0.1):
-        """ Calculate the total accretion rate based on masses and a fraction of the Eddington limit.
+        r""" Calculate the total accretion rate based on masses and a fraction of the Eddington limit.
 
         Parameters
         ----------

--- a/holodeck/plot.py
+++ b/holodeck/plot.py
@@ -611,7 +611,7 @@ def draw_sspars_and_bgpars(axs, xx, sspar, bgpar, nsamp=10, cmap=cm.rainbow_r, c
 def plot_pars(fobs, sspar, bgpar, **kwargs):
     xx= fobs * YR
     fig, axs = figax(figsize = (11,6), ncols=2, nrows=2, sharex = True)
-    axs[0,0].set_ylabel('Total Mass $M/M_\odot$')
+    axs[0,0].set_ylabel(r'Total Mass $M/M_\odot$')
     axs[0,1].set_ylabel('Mass Ratio $q$')
     axs[1,0].set_ylabel('Initial Comoving Distance $d_c$ (Mpc)')
     axs[1,1].set_ylabel('Final Comoving Distance $d_c$ (Mpc)')
@@ -1473,7 +1473,7 @@ def truncate_colormap(cmap, minval=0.0, maxval=1.0, n=100):
 # ====    Below Needs Review / Cleaning    ====
 # =================================================================================================
 
-'''
+r'''
 def plot_bin_pop(pop):
     mt, mr = utils.mtmr_from_m1m2(pop.mass)
     redz = cosmo.a_to_z(pop.scafa)
@@ -1666,4 +1666,4 @@ def _draw_gwb_conf(ax, gwb, **kwargs):
     kwargs['alpha'] = 1.0 - 0.5*(1.0 - kwargs['alpha'])
     ax.plot(freqs, conf[1], **kwargs)
     return
-'''
+r'''

--- a/holodeck/utils.py
+++ b/holodeck/utils.py
@@ -1067,7 +1067,7 @@ def quantiles(
     return percs
 
 def random_power(extr, pdf_index, size=1):
-    rr"""Draw from a power-law PDF with the given index, between the given extrema.
+    r"""Draw from a power-law PDF with the given index, between the given extrema.
 
     NOTE: The power-law index must correspond to the power-law index of $\frac{dN}{dx}$.
           You may need to convert, e.g. $dN/dx = \frac{dN}{d \ln x} \frac{1}{x}$.

--- a/holodeck/utils.py
+++ b/holodeck/utils.py
@@ -1067,7 +1067,7 @@ def quantiles(
     return percs
 
 def random_power(extr, pdf_index, size=1):
-    r"""Draw from a power-law PDF with the given index, between the given extrema.
+    rr"""Draw from a power-law PDF with the given index, between the given extrema.
 
     NOTE: The power-law index must correspond to the power-law index of $\frac{dN}{dx}$.
           You may need to convert, e.g. $dN/dx = \frac{dN}{d \ln x} \frac{1}{x}$.


### PR DESCRIPTION

## Description
Mostly replaced things like:
```python
xlabel="M_{\odot}"
```
with 

```python
xlabel=r"M_{\odot}"
```

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] avoid needless warnings.
