### PR TITLE
Fixing bug in GMR implementation

### DIFF
--- a/holodeck/sams/components.py
+++ b/holodeck/sams/components.py
@@ -521,7 +521,7 @@ class GMR_Power_Law(_Galaxy_Merger_Rate):
 
         xx = (mtot/self._mref)
         mt = np.power(xx, malpha)
-        mp1t = np.power(1.0 + (mt/self._mref_delta), mdelta)
+        mp1t = 1.0 + np.power(mtot/self._mref_delta, mdelta)
         qt = np.power(mrat, qgamma)
 
         rate = norm * mt * mp1t * qt


### PR DESCRIPTION
## Description
This change corrects two issues with the implementation of the GMR equation to match Table 1 in Rodriguez-Gomez et al. (2015). Each change makes a notable impact on the amplitude of the GWB spectrum leading to lower amplitudes across all frequencies by a combined factor of ~1.6.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go